### PR TITLE
Add a compiler plugin for instrumentation.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,10 @@ lazy val root = project.in(file(".")).
     publish := {},
     publishLocal := {}
   ).
-  aggregate(`scala-grading-runtime`, `scala-grading-instragent`)
+  aggregate(
+    `scala-grading-runtime`, `scala-grading-plugin`,
+    `scala-grading-plugin-test`, `scala-grading-instragent`
+  )
 
 lazy val `scala-grading-runtime` = project.in(file("runtime")).
   settings(commonSettings: _*).
@@ -62,6 +65,25 @@ lazy val `scala-grading-runtime` = project.in(file("runtime")).
     libraryDependencies += "org.scala-lang.modules" %% "scala-pickling" % "0.10.0",
     libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.1"
   )
+
+lazy val `scala-grading-plugin` = project.in(file("plugin")).
+  settings(commonSettings: _*).
+  settings(
+    description := "Compiler plugin for instrumentation for scala-grading.",
+    libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value,
+    crossVersion := CrossVersion.full, // because the compiler API is not binary compatible
+    exportJars := true
+  )
+
+lazy val `scala-grading-plugin-test` = project.in(file("plugin-test")).
+  settings(commonSettings: _*).
+  settings(
+    description := "Tests for the scala-grading compiler plugin.",
+    autoCompilerPlugins := true,
+    scalacOptions +=
+      "-P:scalagrading:instrumentClassPrefix:ch.epfl.lamp.grading.tests.instrenabled"
+  ).
+  dependsOn(`scala-grading-runtime`, `scala-grading-plugin` % "plugin")
 
 lazy val `scala-grading-instragent` = project.in(file("instragent")).
   settings(commonSettings: _*).

--- a/plugin-test/src/test/scala/ch/epfl/lamp/grading/tests/InstrumentationTest.scala
+++ b/plugin-test/src/test/scala/ch/epfl/lamp/grading/tests/InstrumentationTest.scala
@@ -1,0 +1,67 @@
+package ch.epfl.lamp.grading.tests
+
+import org.scalatest.FunSuite
+
+import ch.epfl.lamp.grading.instrumented.InstrumentedSuite
+
+import instrenabled._
+import instrdisabled._
+
+class InstrumentationTest extends FunSuite with InstrumentedSuite {
+
+  val instrumentedClass = classOf[InstrumentationEnabled].getName.replace('.', '/')
+
+  test("instrumentation enabled") {
+    val obj = new InstrumentationEnabled
+    var enabled = false
+    profile(M("instrumentedCaller", "()V")) {
+      obj.instrumentedCaller()
+    } {
+      enabled = true
+    }
+    assert(enabled, "instrumentation is disabled on InstrumentationEnabled")
+  }
+
+  test("checkCalled") {
+    val obj = new InstrumentationEnabled
+    profile(M("instrumentedCaller", "()V")) {
+      obj.instrumentedCaller()
+    } {
+      checkCalled(M("instrumentedCallee", "()V"))
+    }
+  }
+
+  test("checkNotCalled") {
+    val obj = new InstrumentationEnabled
+    profile(M("instrumentedCaller", "()V")) {
+      obj.instrumentedCaller()
+    } {
+      checkNotCalled(M("notCalled", "()V"))
+    }
+  }
+
+  test("binary signatures") {
+    val obj = new InstrumentationEnabled
+    var enabled = false
+    profile(M("signature", "(ZCBSIJFDLjava/lang/String;[I[Ljava/lang/String;)I")) {
+      obj.signature(false, 'a', 0, 1, 2, 3L, 1.5f, 1.7, "hello",
+          Array(3), Array("hello"))
+    } {
+      enabled = true
+    }
+    assert(enabled, "instrumentation is disabled on signature() - " +
+        "perhaps the binary encoding of signatures is wrong")
+  }
+
+  test("instrumentation disabled") {
+    val className = classOf[InstrumentationDisabled].getName.replace('.', '/')
+    val obj = new InstrumentationDisabled
+    var enabled = false
+    profile(M(className, "instrumentedCaller", "()V")) {
+      obj.instrumentedCaller()
+    } {
+      enabled = true
+    }
+    assert(!enabled, "instrumentation is enabled on InstrumentationDisabled")
+  }
+}

--- a/plugin-test/src/test/scala/ch/epfl/lamp/grading/tests/instrdisabled/InstrumentationDisabled.scala
+++ b/plugin-test/src/test/scala/ch/epfl/lamp/grading/tests/instrdisabled/InstrumentationDisabled.scala
@@ -1,0 +1,15 @@
+package ch.epfl.lamp.grading.tests.instrdisabled
+
+class InstrumentationDisabled {
+  def instrumentedCallee(): Unit = {
+    assert(true)
+  }
+
+  def notCalled(): Unit = {
+    assert(false)
+  }
+
+  def instrumentedCaller(): Unit = {
+    instrumentedCallee()
+  }
+}

--- a/plugin-test/src/test/scala/ch/epfl/lamp/grading/tests/instrenabled/InstrumentationEnabled.scala
+++ b/plugin-test/src/test/scala/ch/epfl/lamp/grading/tests/instrenabled/InstrumentationEnabled.scala
@@ -1,0 +1,20 @@
+package ch.epfl.lamp.grading.tests.instrenabled
+
+class InstrumentationEnabled {
+  def instrumentedCallee(): Unit = {
+    assert(true)
+  }
+
+  def notCalled(): Unit = {
+    assert(false)
+  }
+
+  def instrumentedCaller(): Unit = {
+    instrumentedCallee()
+  }
+
+  def signature(z: Boolean, c: Char, b: Byte, s: Short, i: Int, j: Long,
+      f: Float, d: Double, str: String, ai: Array[Int], astr: Array[String]): Int = {
+    42
+  }
+}

--- a/plugin/src/main/resources/scalac-plugin.xml
+++ b/plugin/src/main/resources/scalac-plugin.xml
@@ -1,0 +1,4 @@
+<plugin>
+  <name>scalagrading</name>
+  <classname>ch.epfl.lamp.grading.plugin.ScalaGradingPlugin</classname>
+</plugin>

--- a/plugin/src/main/scala/ch/epfl/lamp/grading/plugin/Instrumentation.scala
+++ b/plugin/src/main/scala/ch/epfl/lamp/grading/plugin/Instrumentation.scala
@@ -1,0 +1,117 @@
+package ch.epfl.lamp.grading.plugin
+
+import scala.tools.nsc
+import nsc._
+
+abstract class Instrumentation
+    extends plugins.PluginComponent with transform.Transform {
+
+  val instrumentationOptions: Instrumentation.Options
+
+  import global._
+  import definitions._
+  import rootMirror._
+
+  val phaseName = "gradinginstr"
+
+  override def newPhase(p: nsc.Phase): StdPhase = new InstrumentationPhase(p)
+
+  private class InstrumentationPhase(prev: nsc.Phase) extends Phase(prev) {
+    override def name: String = phaseName
+    override def description: String = "Instrumentation for scala-grading"
+  }
+
+  override protected def newTransformer(unit: CompilationUnit): Transformer =
+    new InstrumentationTransformer(unit)
+
+  private class InstrumentationTransformer(unit: CompilationUnit)
+      extends Transformer {
+
+    private val prefixesWithDots =
+      instrumentationOptions.instrumentedClassPrefixes.map(_ + ".")
+
+    private lazy val ProfilerModule =
+      getRequiredModule("ch.epfl.lamp.grading.instrumented.Profiler")
+    private lazy val ProfilerModuleClass =
+      ProfilerModule.moduleClass
+    private lazy val methodCalledSym =
+      ProfilerModuleClass.info.member(newTermName("methodCalled")).asMethod
+
+    override def transform(tree: Tree): Tree = tree match {
+      case DefDef(mods, name, tparams, vparamss, tpt, rhs) =>
+        val sym = tree.symbol
+        if (!prefixesWithDots.exists(sym.fullName.startsWith(_)) ||
+            sym.isConstructor) {
+          // don't instrument
+          super.transform(tree)
+        } else {
+          // do instrument
+          val className = sym.owner.fullName('/')
+          val methodName = sym.name.toString
+          val methodDescriptor = computeMethodDescriptor(sym.tpe)
+          val newRhs = typer.typed {
+            atPos(tree.pos) {
+              Block(
+                  gen.mkMethodCall(methodCalledSym, List(
+                      Literal(Constant(className)),
+                      Literal(Constant(methodName)),
+                      Literal(Constant(methodDescriptor)))),
+                  rhs)
+            }
+          }
+          treeCopy.DefDef(tree, mods, name, tparams, vparamss, tpt, newRhs)
+        }
+
+      case _ =>
+        super.transform(tree)
+    }
+
+    private def computeMethodDescriptor(tpe: Type): String = {
+      val paramTypeNames = tpe.params map (p => internalName(p.tpe))
+      val resultTypeName = internalName(tpe.resultType)
+      paramTypeNames.mkString("(", "", ")") + resultTypeName
+    }
+
+    /** Computes the internal name for a type. */
+    private def internalName(tpe: Type): String = tpe.normalize match {
+      case ThisType(ArrayClass)            => internalClassName(ObjectClass)
+      case ThisType(sym)                   => internalClassName(sym)
+      case SingleType(_, sym)              => internalClassName(sym)
+      case ConstantType(_)                 => internalName(tpe.underlying)
+      case TypeRef(_, sym, args)           => internalName(sym, args)
+      case ClassInfoType(_, _, ArrayClass) => abort("ClassInfoType to ArrayClass!")
+      case ClassInfoType(_, _, sym)        => internalClassName(sym)
+      case tpe: AnnotatedType              => internalName(tpe.underlying)
+
+      case norm =>
+        abort("Unknown type: %s, %s [%s, %s] TypeRef? %s".format(
+            tpe, norm, tpe.getClass, norm.getClass, tpe.isInstanceOf[TypeRef]))
+    }
+
+    private def internalName(sym: Symbol, targs: List[Type]): String = sym match {
+      case ArrayClass => "[" + internalName(targs.head)
+      case _          => internalClassName(sym)
+    }
+
+    private def internalClassName(sym: Symbol): String = sym match {
+      case UnitClass    => "V"
+      case BooleanClass => "Z"
+      case CharClass    => "C"
+      case ByteClass    => "B"
+      case ShortClass   => "S"
+      case IntClass     => "I"
+      case LongClass    => "J"
+      case FloatClass   => "F"
+      case DoubleClass  => "D"
+
+      case _ =>
+        "L" + sym.fullName('/') + (if (sym.isModuleClass) "$" else "") + ";"
+    }
+  }
+}
+
+object Instrumentation {
+  trait Options {
+    def instrumentedClassPrefixes: Set[String]
+  }
+}

--- a/plugin/src/main/scala/ch/epfl/lamp/grading/plugin/ScalaGradingPlugin.scala
+++ b/plugin/src/main/scala/ch/epfl/lamp/grading/plugin/ScalaGradingPlugin.scala
@@ -1,0 +1,50 @@
+package ch.epfl.lamp.grading.plugin
+
+import scala.tools.nsc._
+import scala.tools.nsc.plugins.{
+  Plugin => NscPlugin, PluginComponent => NscPluginComponent
+}
+
+class ScalaGradingPlugin(val global: Global) extends NscPlugin {
+  import global._
+
+  val name = "scalagrading"
+  val description = "Instrumentation for scala-grading"
+  val components = {
+    if (global.forScaladoc)
+      List[NscPluginComponent]()
+    else
+      List[NscPluginComponent](InstrumentationComponent)
+  }
+
+  object scalaGradingOptions extends Instrumentation.Options {
+    var instrumentedClassPrefixes: Set[String] = Set.empty
+  }
+
+  object InstrumentationComponent extends {
+    val global: ScalaGradingPlugin.this.global.type = ScalaGradingPlugin.this.global
+    val instrumentationOptions = ScalaGradingPlugin.this.scalaGradingOptions
+    override val runsAfter = List("cleanup", "delambdafy")
+    override val runsBefore = List("icode", "bcode")
+  } with Instrumentation
+
+  override def processOptions(options: List[String],
+      error: String => Unit): Unit = {
+    import scalaGradingOptions._
+
+    for (option <- options) {
+      if (option.startsWith("instrumentClassPrefix:")) {
+        instrumentedClassPrefixes +=
+          option.stripPrefix("instrumentClassPrefix:")
+      } else {
+        error("Option not understood: " + option)
+      }
+    }
+  }
+
+  override val optionsHelp: Option[String] = Some(s"""
+      |  -P:$name:instrumentClassPrefix:somepack.path
+      |     Instrument all classes in the somepack.path package
+      """.stripMargin)
+
+}


### PR DESCRIPTION
The compiler plugin is an alternative to the Java agent, which is probably more reliable.

The `scala-grading-plugin-test` shows how to setup a project to be instrumented, and contains the tests of that setup.
