### PR TITLE
Fix binary class names for module classes.

### DIFF
--- a/plugin-test/src/test/scala/ch/epfl/lamp/grading/tests/InstrumentationTest.scala
+++ b/plugin-test/src/test/scala/ch/epfl/lamp/grading/tests/InstrumentationTest.scala
@@ -40,6 +40,19 @@ class InstrumentationTest extends FunSuite with InstrumentedSuite {
     }
   }
 
+  test("instrumentation is enabled on module classes") {
+    val className = InstrumentationEnabled.getClass.getName.replace('.', '/')
+    var enabled = false
+    profile(M(className, "instrumentedMethod", "()V")) {
+      InstrumentationEnabled.instrumentedMethod()
+    } {
+      enabled = true
+      checkCalled(M(className, "instrumentedMethod", "()V"))
+    }
+    assert(enabled,
+        "instrumentation was disabled on object InstrumentationEnabled")
+  }
+
   test("binary signatures") {
     val obj = new InstrumentationEnabled
     var enabled = false

--- a/plugin-test/src/test/scala/ch/epfl/lamp/grading/tests/instrenabled/InstrumentationEnabled.scala
+++ b/plugin-test/src/test/scala/ch/epfl/lamp/grading/tests/instrenabled/InstrumentationEnabled.scala
@@ -18,3 +18,9 @@ class InstrumentationEnabled {
     42
   }
 }
+
+object InstrumentationEnabled {
+  def instrumentedMethod(): Unit = {
+    assert(true)
+  }
+}

--- a/plugin/src/main/scala/ch/epfl/lamp/grading/plugin/Instrumentation.scala
+++ b/plugin/src/main/scala/ch/epfl/lamp/grading/plugin/Instrumentation.scala
@@ -46,7 +46,7 @@ abstract class Instrumentation
           super.transform(tree)
         } else {
           // do instrument
-          val className = sym.owner.fullName('/')
+          val className = classBinaryName(sym.owner)
           val methodName = sym.name.toString
           val methodDescriptor = computeMethodDescriptor(sym.tpe)
           val newRhs = typer.typed {
@@ -103,10 +103,11 @@ abstract class Instrumentation
       case LongClass    => "J"
       case FloatClass   => "F"
       case DoubleClass  => "D"
-
-      case _ =>
-        "L" + sym.fullName('/') + (if (sym.isModuleClass) "$" else "") + ";"
+      case _            => "L" + classBinaryName(sym) + ";"
     }
+
+    private def classBinaryName(sym: Symbol): String =
+      sym.fullName('/') + (if (sym.isModuleClass) "$" else "")
   }
 }
 


### PR DESCRIPTION
Methods in module classes (aka companion objects) were registered as belonging to the class with the trailing '$' that module classes are supposed to have. This commit fixes that issue.
